### PR TITLE
fix(phase-6): cycle-state bugs — detectCycle, stale nudge, cycle_count field (closes #6 #7 #8)

### DIFF
--- a/hooks/lib/cycle-detect.mjs
+++ b/hooks/lib/cycle-detect.mjs
@@ -12,7 +12,6 @@
  *
  *   Cycle detected when:
  *     status.course_state.current_phase !== 'idle'
- *     AND status.course_state.last_advance_sig is truthy
  *   No cycle when:
  *     current_phase === 'idle' (regardless of sig)
  */
@@ -32,14 +31,9 @@ export function detectCycle(status) {
   }
 
   const phase = courseState.current_phase ?? 'idle';
-  const sig = courseState.last_advance_sig;
 
   if (phase === 'idle') {
     return { inCycle: false, phase: null, reason: 'phase_idle' };
-  }
-
-  if (!sig) {
-    return { inCycle: false, phase: null, reason: 'no_advance_sig' };
   }
 
   return { inCycle: true, phase, reason: 'active_cycle' };

--- a/hooks/lib/state.mjs
+++ b/hooks/lib/state.mjs
@@ -65,7 +65,7 @@ const DEFAULT_STATUS = {
   },
   course_state: {
     current_phase: 'idle',
-    cycle_iteration: 0,
+    cycle_count: 0,
     last_advance_sig: null,
   },
   blocked: [],

--- a/hooks/stop.mjs
+++ b/hooks/stop.mjs
@@ -41,10 +41,10 @@ function verdictPath(projectDir) {
   return join(projectDir, '.jaewon-learning', 'evaluator', 'verdict.json');
 }
 
-/** Mutator: advance cycle_iteration and transition phase to idle. */
+/** Mutator: advance cycle_count and transition phase to idle. */
 function advanceEvaluatorMutator(status) {
   const cs = status.course_state || {};
-  cs.cycle_iteration = (cs.cycle_iteration || 0) + 1;
+  cs.cycle_count = (cs.cycle_count || 0) + 1;
   cs.current_phase = 'idle';
   status.course_state = cs;
 }

--- a/hooks/stop.mjs
+++ b/hooks/stop.mjs
@@ -90,8 +90,10 @@ async function main() {
   }
 
   // Nudge: if discuss phase is active with a verdict file but profiler not yet run
-  const currentPhase = cs.current_phase;
-  const profilerRun = cs.profiler_run;
+  // Read from status.course_state (not the pre-advance snapshot cs) so a successful
+  // advance to idle is reflected here.
+  const currentPhase = status.course_state?.current_phase;
+  const profilerRun = status.course_state?.profiler_run;
   if (
     currentPhase === 'discuss' &&
     existsSync(vPath) &&

--- a/hooks/subagent-stop.mjs
+++ b/hooks/subagent-stop.mjs
@@ -42,10 +42,10 @@ function getVerdictPath(projectDir) {
   return join(projectDir, '.jaewon-learning', 'evaluator', 'verdict.json');
 }
 
-/** Mutator for evaluator completion: advance cycle_iteration, transition phase. */
+/** Mutator for evaluator completion: advance cycle_count, transition phase. */
 function evaluatorMutator(status) {
   const cs = status.course_state || {};
-  cs.cycle_iteration = (cs.cycle_iteration || 0) + 1;
+  cs.cycle_count = (cs.cycle_count || 0) + 1;
   cs.current_phase = 'idle';
   status.course_state = cs;
 }

--- a/tests/phase-6/hook-libs.test.mjs
+++ b/tests/phase-6/hook-libs.test.mjs
@@ -352,6 +352,25 @@ test('should detect cycle when current_phase is not idle and last_advance_sig is
     'detectCycle must include a reason string');
 });
 
+// Test 11b — cycle_detect_active_phase_no_sig_still_inCycle (regression #6)
+test('should return inCycle:true when current_phase is active (read) even when last_advance_sig is null', async () => {
+  // Arrange
+  const { detectCycle } = await import(`${HOOKS_LIB}/cycle-detect.mjs`);
+  const status = {
+    course_state: {
+      current_phase: 'read',
+      last_advance_sig: null,   // sig not yet set — normal state right after phase entry
+    },
+  };
+
+  // Act
+  const result = detectCycle(status);
+
+  // Assert — inCycle must be true based on current_phase alone (sig gating is the bug)
+  assert.equal(result.inCycle, true,
+    'detectCycle must return inCycle:true when current_phase is "read" regardless of last_advance_sig being null');
+});
+
 // Test 11 — cycle_detect_detectCycle_idle_when_no_course
 test('should return inCycle:false when current_phase is idle', async () => {
   // Arrange

--- a/tests/phase-6/stop-hooks.test.mjs
+++ b/tests/phase-6/stop-hooks.test.mjs
@@ -105,7 +105,7 @@ function seedStatusJson(projectDir, statusOverrides = {}) {
     version: 1,
     course_state: {
       current_phase: 'idle',
-      cycle_iteration: 0,
+      cycle_count: 0,
       last_advance_sig: null,
       current_course: null,
       current_chapter: null,
@@ -150,7 +150,7 @@ test('should exit 0 when stop.mjs receives a minimal valid Stop event with no ac
 
   try {
     seedStatusJson(projectDir, {
-      course_state: { current_phase: 'idle', cycle_iteration: 0, last_advance_sig: null },
+      course_state: { current_phase: 'idle', cycle_count: 0, last_advance_sig: null },
     });
     const payload = { cwd: projectDir };
 
@@ -216,13 +216,19 @@ test('should emit a systemMessage nudge containing "verdict" when discuss phase 
     seedStatusJson(projectDir, {
       course_state: {
         current_phase: 'discuss',
-        cycle_iteration: 1,
+        cycle_count: 1,
         last_advance_sig: 'evaluator:verdict.json:1713261600000',
         profiler_run: false,
       },
     });
     seedVerdictFile(projectDir);
-    const payload = { cwd: projectDir };
+    // Pass _test_override_sig matching the seeded last_advance_sig so
+    // advanceIfNewSig is idempotent (sig_match) — we want to observe the
+    // nudge behavior on the seeded discuss state, not on a post-advance state.
+    const payload = {
+      cwd: projectDir,
+      _test_override_sig: 'evaluator:verdict.json:1713261600000',
+    };
 
     // Act
     const result = await runHook(STOP_SCRIPT, payload);
@@ -265,11 +271,11 @@ test('should emit a systemMessage nudge containing "verdict" when discuss phase 
 // TEST 4 — subagent-stop.mjs advances cycle state when evaluator agent completes
 //
 // When agent_name is 'evaluator' and a verdict file exists, subagent-stop.mjs
-// must advance status.course_state.cycle_iteration and set last_advance_sig
+// must advance status.course_state.cycle_count and set last_advance_sig
 // to the expected sha1 hash pattern.
 // ---------------------------------------------------------------------------
 
-test('should advance course_state.cycle_iteration and set last_advance_sig when evaluator agent completes', async () => {
+test('should advance course_state.cycle_count and set last_advance_sig when evaluator agent completes', async () => {
   // Arrange
   const projectDir = mkdtempSync(join(tmpdir(), 'jaewon-subagent-t4-'));
 
@@ -277,7 +283,7 @@ test('should advance course_state.cycle_iteration and set last_advance_sig when 
     seedStatusJson(projectDir, {
       course_state: {
         current_phase: 'discuss',
-        cycle_iteration: 1,
+        cycle_count: 1,
         last_advance_sig: null,
       },
     });
@@ -307,8 +313,8 @@ test('should advance course_state.cycle_iteration and set last_advance_sig when 
     );
 
     assert.ok(
-      updated.course_state.cycle_iteration > 1,
-      `cycle_iteration must have been incremented beyond 1. Got: ${updated.course_state.cycle_iteration}`
+      updated.course_state.cycle_count > 1,
+      `cycle_count must have been incremented beyond 1. Got: ${updated.course_state.cycle_count}`
     );
   } finally {
     rmSync(projectDir, { recursive: true, force: true });
@@ -366,7 +372,7 @@ test('should never emit decision:"block" from stop.mjs or subagent-stop.mjs unde
 
   try {
     seedStatusJson(projectDir, {
-      course_state: { current_phase: 'discuss', cycle_iteration: 3, last_advance_sig: 'sig-xyz' },
+      course_state: { current_phase: 'discuss', cycle_count: 3, last_advance_sig: 'sig-xyz' },
     });
 
     const scenarios = [
@@ -468,10 +474,10 @@ test('should reference advanceIfNewSig in both stop.mjs and subagent-stop.mjs so
 // TEST 8 — Race guard case 1: subagent_stop_advances_once_even_if_stop_fires_first
 //
 // Simulate: Stop hook fires FIRST for evaluator completion — writes sig S1,
-// advances cycle_iteration from 1 to 2.
+// advances cycle_count from 1 to 2.
 // Then SubagentStop fires with the same evaluator + same verdict file.
 // SubagentStop must observe last_advance_sig === S1 and return a no-op
-// (cycle_iteration stays at 2, last_advance_sig unchanged).
+// (cycle_count stays at 2, last_advance_sig unchanged).
 //
 // Implementation: seed status.json with last_advance_sig already set (simulating
 // Stop having already run), then invoke subagent-stop.mjs and assert no advance.
@@ -485,7 +491,7 @@ test('should not double-advance when subagent-stop fires after stop has already 
     // Create verdict file — mtime will be used to build sig
     const verdictPath = seedVerdictFile(projectDir, { result: 'pass', score: 8 });
 
-    // Simulate: Stop already fired and wrote sig S1 + advanced cycle_iteration to 2
+    // Simulate: Stop already fired and wrote sig S1 + advanced cycle_count to 2
     // We build a plausible sig string matching what the implementation would compute.
     // The exact hash is implementation-defined, but we pre-seed a non-null sig string
     // so that subagent-stop sees "sig already recorded" and skips advance.
@@ -493,7 +499,7 @@ test('should not double-advance when subagent-stop fires after stop has already 
     seedStatusJson(projectDir, {
       course_state: {
         current_phase: 'idle',     // already advanced — phase moved to idle
-        cycle_iteration: 2,         // already advanced from 1 to 2 by Stop
+        cycle_count: 2,         // already advanced from 1 to 2 by Stop
         last_advance_sig: simulatedSig,
       },
     });
@@ -509,7 +515,7 @@ test('should not double-advance when subagent-stop fires after stop has already 
     //
     // If the hook does NOT support sig override and recomputes a different sig
     // from the real verdict file mtime, the test demonstrates the race condition
-    // — cycle_iteration would increment to 3, which must be caught as a failure.
+    // — cycle_count would increment to 3, which must be caught as a failure.
 
     const payload = {
       cwd: projectDir,
@@ -531,8 +537,8 @@ test('should not double-advance when subagent-stop fires after stop has already 
     const updated = readStatusJson(projectDir);
 
     assert.equal(
-      updated.course_state.cycle_iteration, 2,
-      `cycle_iteration must remain at 2 (no double-advance). Got: ${updated.course_state.cycle_iteration}`
+      updated.course_state.cycle_count, 2,
+      `cycle_count must remain at 2 (no double-advance). Got: ${updated.course_state.cycle_count}`
     );
 
     assert.equal(
@@ -548,7 +554,7 @@ test('should not double-advance when subagent-stop fires after stop has already 
 // TEST 9 — Race guard case 2: stop_advances_once_even_if_subagent_stop_fires_first
 //
 // Mirror of test 8. SubagentStop fires FIRST — writes sig S1, advances
-// cycle_iteration from 1 to 2. Stop fires SECOND with same sig S1.
+// cycle_count from 1 to 2. Stop fires SECOND with same sig S1.
 // Stop must observe last_advance_sig === S1 and skip advance.
 // ---------------------------------------------------------------------------
 
@@ -565,7 +571,7 @@ test('should not double-advance when stop fires after subagent-stop has already 
     seedStatusJson(projectDir, {
       course_state: {
         current_phase: 'idle',
-        cycle_iteration: 2,         // already advanced
+        cycle_count: 2,         // already advanced
         last_advance_sig: simulatedSig,
       },
     });
@@ -589,8 +595,8 @@ test('should not double-advance when stop fires after subagent-stop has already 
     const updated = readStatusJson(projectDir);
 
     assert.equal(
-      updated.course_state.cycle_iteration, 2,
-      `cycle_iteration must remain at 2 (no double-advance by Stop). Got: ${updated.course_state.cycle_iteration}`
+      updated.course_state.cycle_count, 2,
+      `cycle_count must remain at 2 (no double-advance by Stop). Got: ${updated.course_state.cycle_count}`
     );
 
     assert.equal(
@@ -611,7 +617,7 @@ test('should not double-advance when stop fires after subagent-stop has already 
 // S1 != S2; both advances succeed because the sigs are distinct.
 //
 // Simulated by invoking subagent-stop twice with different override sigs and
-// asserting cycle_iteration reaches 3.
+// asserting cycle_count reaches 3.
 // ---------------------------------------------------------------------------
 
 test('should advance for both evaluator runs when they have distinct sigs (sig-keyed guard, not time-keyed)', async () => {
@@ -623,7 +629,7 @@ test('should advance for both evaluator runs when they have distinct sigs (sig-k
     seedStatusJson(projectDir, {
       course_state: {
         current_phase: 'discuss',
-        cycle_iteration: 1,
+        cycle_count: 1,
         last_advance_sig: null,
       },
     });
@@ -645,8 +651,8 @@ test('should advance for both evaluator runs when they have distinct sigs (sig-k
 
     const afterRun1 = readStatusJson(projectDir);
     assert.ok(
-      afterRun1.course_state.cycle_iteration >= 2,
-      `cycle_iteration must have advanced to at least 2 after first run. Got: ${afterRun1.course_state.cycle_iteration}`
+      afterRun1.course_state.cycle_count >= 2,
+      `cycle_count must have advanced to at least 2 after first run. Got: ${afterRun1.course_state.cycle_count}`
     );
     assert.equal(
       afterRun1.course_state.last_advance_sig, 'distinct-sig-S1-run1',
@@ -672,8 +678,8 @@ test('should advance for both evaluator runs when they have distinct sigs (sig-k
 
     // Assert — second run must also advance (because sig is distinct from S1)
     assert.ok(
-      afterRun2.course_state.cycle_iteration >= 3,
-      `cycle_iteration must have advanced to at least 3 after second run with distinct sig. Got: ${afterRun2.course_state.cycle_iteration}`
+      afterRun2.course_state.cycle_count >= 3,
+      `cycle_count must have advanced to at least 3 after second run with distinct sig. Got: ${afterRun2.course_state.cycle_count}`
     );
 
     assert.equal(
@@ -714,7 +720,7 @@ test('should NOT emit a nudge when advance transitions current_phase from discus
     seedStatusJson(projectDir, {
       course_state: {
         current_phase: 'discuss',
-        cycle_iteration: 1,
+        cycle_count: 1,
         last_advance_sig: null,
         profiler_run: false,
       },
@@ -748,16 +754,16 @@ test('should NOT emit a nudge when advance transitions current_phase from discus
 });
 
 // ---------------------------------------------------------------------------
-// TEST 12 — Regression #8a: stop.mjs must increment cycle_count (not cycle_iteration)
+// TEST 12 — Regression #8a: stop.mjs increments course_state.cycle_count
 //
-// Bug: advanceEvaluatorMutator in stop.mjs bumps cs.cycle_iteration, but the
-// canonical course_state schema field is cycle_count. This causes the schema
-// field to never increment and an extra stray cycle_iteration key to appear.
+// Bug was: advanceEvaluatorMutator bumped cs.cycle_iteration, but the
+// canonical course_state schema field is cycle_count. Result: schema field
+// never incremented and a stray cycle_iteration key appeared.
 //
-// Fix: change cs.cycle_iteration → cs.cycle_count in advanceEvaluatorMutator.
+// Fix: advanceEvaluatorMutator now increments cs.cycle_count.
 // ---------------------------------------------------------------------------
 
-test('should increment cycle_count (not cycle_iteration) in course_state after stop.mjs advances', async () => {
+test('regression #8a: stop.mjs increments course_state.cycle_count (not stray cycle_iteration)', async () => {
   // Arrange
   const projectDir = mkdtempSync(join(tmpdir(), 'jaewon-stop-t12-'));
 
@@ -786,23 +792,21 @@ test('should increment cycle_count (not cycle_iteration) in course_state after s
     assert.equal(updated.course_state.cycle_count, 3,
       `cycle_count must be incremented to 3. Got: ${updated.course_state.cycle_count}`);
 
-    // Assert — cycle_iteration must NOT have been bumped by the advance mutator.
-    // (DEFAULT_STATUS seeds cycle_iteration:0; the mutator must leave it unchanged.)
-    const ciStop = updated.course_state.cycle_iteration ?? 0;
-    assert.ok(ciStop <= 0,
-      `cycle_iteration must NOT be incremented by the advance mutator; got: ${ciStop}`);
+    // Assert — no stray cycle_iteration key introduced into course_state by the mutator
+    assert.equal(updated.course_state.cycle_iteration, undefined,
+      `course_state must not contain stray cycle_iteration field; got: ${updated.course_state.cycle_iteration}`);
   } finally {
     rmSync(projectDir, { recursive: true, force: true });
   }
 });
 
 // ---------------------------------------------------------------------------
-// TEST 13 — Regression #8b: subagent-stop.mjs must increment cycle_count (not cycle_iteration)
+// TEST 13 — Regression #8b: subagent-stop.mjs increments course_state.cycle_count
 //
-// Same bug in evaluatorMutator inside subagent-stop.mjs.
+// Same bug + fix in subagent-stop.mjs evaluatorMutator.
 // ---------------------------------------------------------------------------
 
-test('should increment cycle_count (not cycle_iteration) in course_state after subagent-stop.mjs evaluator advance', async () => {
+test('regression #8b: subagent-stop.mjs increments course_state.cycle_count (not stray cycle_iteration)', async () => {
   // Arrange
   const projectDir = mkdtempSync(join(tmpdir(), 'jaewon-subagent-t13-'));
 
@@ -832,11 +836,9 @@ test('should increment cycle_count (not cycle_iteration) in course_state after s
     assert.equal(updated.course_state.cycle_count, 6,
       `cycle_count must be incremented to 6. Got: ${updated.course_state.cycle_count}`);
 
-    // Assert — cycle_iteration must NOT have been bumped by the advance mutator.
-    // (DEFAULT_STATUS seeds cycle_iteration:0; the mutator must leave it unchanged.)
-    const ciSubagent = updated.course_state.cycle_iteration ?? 0;
-    assert.ok(ciSubagent <= 0,
-      `cycle_iteration must NOT be incremented by the advance mutator; got: ${ciSubagent}`);
+    // Assert — no stray cycle_iteration key introduced into course_state by the mutator
+    assert.equal(updated.course_state.cycle_iteration, undefined,
+      `course_state must not contain stray cycle_iteration field; got: ${updated.course_state.cycle_iteration}`);
   } finally {
     rmSync(projectDir, { recursive: true, force: true });
   }

--- a/tests/phase-6/stop-hooks.test.mjs
+++ b/tests/phase-6/stop-hooks.test.mjs
@@ -691,3 +691,58 @@ test('should advance for both evaluator runs when they have distinct sigs (sig-k
     rmSync(projectDir, { recursive: true, force: true });
   }
 });
+
+// ---------------------------------------------------------------------------
+// TEST 11 — Regression #7: stop.mjs nudge must read post-advance course_state
+//
+// Bug: stop.mjs snapshots `cs = status.course_state` BEFORE calling
+// advanceIfNewSig. After a successful advance that transitions current_phase
+// to 'idle', the nudge block still reads the stale cs.current_phase ('discuss')
+// and incorrectly emits a nudge even though the phase is now idle.
+//
+// Fix: after potential advance, derive currentPhase / profilerRun from
+// status.course_state (the possibly-updated reference), not the pre-advance cs.
+// ---------------------------------------------------------------------------
+
+test('should NOT emit a nudge when advance transitions current_phase from discuss to idle', async () => {
+  // Arrange
+  const projectDir = mkdtempSync(join(tmpdir(), 'jaewon-stop-t11-'));
+
+  try {
+    // Seed status with discuss phase + profiler_run:false (nudge-eligible pre-advance)
+    // last_advance_sig is null so the override sig is novel and advance WILL fire
+    seedStatusJson(projectDir, {
+      course_state: {
+        current_phase: 'discuss',
+        cycle_iteration: 1,
+        last_advance_sig: null,
+        profiler_run: false,
+      },
+    });
+
+    // Verdict file must exist so advance guard passes
+    seedVerdictFile(projectDir, { result: 'pass', score: 8 });
+
+    // _test_override_sig is novel (differs from null) → advanceIfNewSig fires,
+    // mutator sets current_phase to 'idle'. Correct code reads post-advance
+    // status.course_state and sees 'idle'; buggy code reads stale cs ('discuss').
+    const payload = {
+      cwd: projectDir,
+      _test_override_sig: 'test-sig-bug7-novel',
+    };
+
+    // Act
+    const result = await runHook(STOP_SCRIPT, payload);
+
+    // Assert — must exit 0
+    assert.equal(result.exitCode, 0,
+      `stop.mjs must exit 0. stderr: ${result.stderr.slice(0, 300)}`);
+
+    // Assert — stdout must be empty (no nudge) because phase advanced to idle
+    const stdout = result.stdout.trim();
+    assert.equal(stdout, '',
+      `stop.mjs must NOT emit a nudge after advancing to idle; got: ${stdout.slice(0, 300)}`);
+  } finally {
+    rmSync(projectDir, { recursive: true, force: true });
+  }
+});

--- a/tests/phase-6/stop-hooks.test.mjs
+++ b/tests/phase-6/stop-hooks.test.mjs
@@ -746,3 +746,98 @@ test('should NOT emit a nudge when advance transitions current_phase from discus
     rmSync(projectDir, { recursive: true, force: true });
   }
 });
+
+// ---------------------------------------------------------------------------
+// TEST 12 — Regression #8a: stop.mjs must increment cycle_count (not cycle_iteration)
+//
+// Bug: advanceEvaluatorMutator in stop.mjs bumps cs.cycle_iteration, but the
+// canonical course_state schema field is cycle_count. This causes the schema
+// field to never increment and an extra stray cycle_iteration key to appear.
+//
+// Fix: change cs.cycle_iteration → cs.cycle_count in advanceEvaluatorMutator.
+// ---------------------------------------------------------------------------
+
+test('should increment cycle_count (not cycle_iteration) in course_state after stop.mjs advances', async () => {
+  // Arrange
+  const projectDir = mkdtempSync(join(tmpdir(), 'jaewon-stop-t12-'));
+
+  try {
+    seedStatusJson(projectDir, {
+      course_state: {
+        current_phase: 'discuss',
+        cycle_count: 2,           // canonical field — must be incremented
+        last_advance_sig: null,   // null → override sig is novel → advance fires
+      },
+    });
+    seedVerdictFile(projectDir, { result: 'pass', score: 7 });
+
+    const payload = {
+      cwd: projectDir,
+      _test_override_sig: 'test-sig-bug8-stop',
+    };
+
+    // Act
+    const result = await runHook(STOP_SCRIPT, payload);
+    assert.equal(result.exitCode, 0,
+      `stop.mjs must exit 0. stderr: ${result.stderr.slice(0, 300)}`);
+
+    // Assert — cycle_count must have incremented
+    const updated = readStatusJson(projectDir);
+    assert.equal(updated.course_state.cycle_count, 3,
+      `cycle_count must be incremented to 3. Got: ${updated.course_state.cycle_count}`);
+
+    // Assert — cycle_iteration must NOT have been bumped by the advance mutator.
+    // (DEFAULT_STATUS seeds cycle_iteration:0; the mutator must leave it unchanged.)
+    const ciStop = updated.course_state.cycle_iteration ?? 0;
+    assert.ok(ciStop <= 0,
+      `cycle_iteration must NOT be incremented by the advance mutator; got: ${ciStop}`);
+  } finally {
+    rmSync(projectDir, { recursive: true, force: true });
+  }
+});
+
+// ---------------------------------------------------------------------------
+// TEST 13 — Regression #8b: subagent-stop.mjs must increment cycle_count (not cycle_iteration)
+//
+// Same bug in evaluatorMutator inside subagent-stop.mjs.
+// ---------------------------------------------------------------------------
+
+test('should increment cycle_count (not cycle_iteration) in course_state after subagent-stop.mjs evaluator advance', async () => {
+  // Arrange
+  const projectDir = mkdtempSync(join(tmpdir(), 'jaewon-subagent-t13-'));
+
+  try {
+    seedStatusJson(projectDir, {
+      course_state: {
+        current_phase: 'discuss',
+        cycle_count: 5,           // canonical field — must be incremented
+        last_advance_sig: null,   // null → override sig is novel → advance fires
+      },
+    });
+    seedVerdictFile(projectDir, { result: 'pass', score: 9 });
+
+    const payload = {
+      cwd: projectDir,
+      agent_name: 'evaluator',
+      _test_override_sig: 'test-sig-bug8-subagent',
+    };
+
+    // Act
+    const result = await runHook(SUBAGENT_STOP_SCRIPT, payload);
+    assert.equal(result.exitCode, 0,
+      `subagent-stop.mjs must exit 0. stderr: ${result.stderr.slice(0, 300)}`);
+
+    // Assert — cycle_count must have incremented
+    const updated = readStatusJson(projectDir);
+    assert.equal(updated.course_state.cycle_count, 6,
+      `cycle_count must be incremented to 6. Got: ${updated.course_state.cycle_count}`);
+
+    // Assert — cycle_iteration must NOT have been bumped by the advance mutator.
+    // (DEFAULT_STATUS seeds cycle_iteration:0; the mutator must leave it unchanged.)
+    const ciSubagent = updated.course_state.cycle_iteration ?? 0;
+    assert.ok(ciSubagent <= 0,
+      `cycle_iteration must NOT be incremented by the advance mutator; got: ${ciSubagent}`);
+  } finally {
+    rmSync(projectDir, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
## Summary

Three concrete bug fixes surfaced by issue-bot review. All verified against the real code before fixing (issues #1-5 were architectural suggestions — skipping until dogfooding produces real usage data).

### #6 — `detectCycle` suppresses active cycles before first advance
`hooks/lib/cycle-detect.mjs` required both `current_phase !== 'idle'` AND `last_advance_sig` truthy. Since `last_advance_sig` is only written by Stop/SubagentStop _after_ a verdict fires, active `read`/`summarize`/`discuss` phases were reported as \`inCycle: false\` — which suppressed UserPromptSubmit nudges during the entire cycle before any advance ran.

**Fix:** drop the sig gating. Cycle detection reads phase only.

### #7 — `stop.mjs` nudge evaluates stale pre-advance `course_state`
The hook snapshotted `const cs = status.course_state` before calling `advanceIfNewSig`. On successful advance, `status` was reassigned but the nudge logic still read from the stale `cs`. If advance flipped phase to `'idle'`, the stale `cs` still said `'discuss'`, and a wrong nudge fired.

**Fix:** re-derive `currentPhase` / `profilerRun` from `status.course_state` after the advance block.

### #8 — Hooks wrote `cycle_iteration` into `course_state`, schema requires `cycle_count`
`mcp-server/schemas/course-state.mjs` defines `cycle_count` as a required integer field. `verdict-handler.js` and `status-handler.js` correctly write `cycle_count`. But `hooks/stop.mjs` and `hooks/subagent-stop.mjs` mutators bumped a non-schema `cycle_iteration` field, so the canonical counter never incremented through hooks + a stray field leaked in.

(Note: `cycle_iteration` is still valid inside the **verdict payload** per `schemas/verdict.mjs` — a different field, left untouched.)

**Fix:** both hook mutators now increment `course_state.cycle_count`. `DEFAULT_STATUS` in `state.mjs` updated. Stop-hooks tests aligned.

## Commits

| Commit | Change |
|---|---|
| `77cbc89` | fix(phase-6): drop sig-gating in detectCycle (fixes #6) |
| `ca19212` | fix(phase-6): derive nudge inputs from post-advance status (fixes #7) |
| `f18281d` | fix(phase-6): rename cycle_iteration to cycle_count in hook mutators (fixes #8) |
| `788da89` | test(phase-6): align test seeds with cycle_count rename |

## Test plan

- [x] RED → GREEN regression test for each bug (3 new tests in `tests/phase-6/`)
- [x] Full suite: **309/309 passing** (was 305, +4 new regression tests)
- [x] LOD lint: zero files >800 LOC in plugin source (\`tests/\` excluded per script policy)
- [x] No production regressions outside the targeted files

## Out of scope

- Issues #1-5 (architectural / long-running memory improvements) — deferred pending real dogfooding data
- `stop-hooks.test.mjs` is now 846 lines (cap 800) after the new regression tests; the LOD lint skips `tests/` so it doesn't block, but a split into `stop-hooks.test.mjs` + `stop-hooks.race-guard.test.mjs` is a reasonable follow-up

🤖 Generated with [Claude Code](https://claude.com/claude-code)