### PR TITLE
chore: normalize cycle_count terminology across skills + tests (closes #10)

### DIFF
--- a/mcp-server/schemas/verdict.mjs
+++ b/mcp-server/schemas/verdict.mjs
@@ -13,6 +13,12 @@
  *     evidence: string[],
  *     next_action: 'reread'|'rediscuss'|'merge',
  *     cycle_iteration: integer >= 1 }
+ *
+ * NOTE on cycle_iteration: this is a VERDICT PAYLOAD field — the ordinal
+ * of the cycle that produced this verdict, stamped at verdict emission
+ * time. It is intentionally distinct from `course_state.cycle_count`
+ * (the persisted counter in `.jaewon-learning/status.json`, mutated by
+ * Stop/SubagentStop hooks). Do not conflate the two. See issues #8, #10.
  */
 
 const VERDICT_ENUM = ['incomplete', 'partial', 'mastery'];

--- a/skills/verdict/SKILL.md
+++ b/skills/verdict/SKILL.md
@@ -31,7 +31,7 @@ next action via dict-driven registry. Enforces bounded loop: max 3 iterations of
 - Next-action dispatch is dict-driven (ACTIONS registry); zero switch/case on verdict
 - push_tactic_snapshot loaded from status or rebuilt if hash is stale
 - profiler always spawned after any discuss, regardless of verdict outcome
-- Bounded loop: if cycle_iteration > 3, escalate to learner
+- Bounded loop: if cycle_count > 3, escalate to learner
 - All agent calls use Task() with explicit named arguments
 </Execution_Policy>
 
@@ -60,10 +60,10 @@ ACTIONS = {"merge": run_merge, "rediscuss": run_rediscuss, "reread": run_reread}
 ACTIONS[verdict.next_action](course_slug, chapter)
 ```
 - **merge**: spawn git-manager (merge `course/<slug>` → main, push); spawn dashboard-builder; spawn git-manager (commit + tag milestone).
-- **rediscuss**: update status `phase=discuss, cycle_iteration++`.
+- **rediscuss**: update status `phase=discuss, cycle_count++`.
 - **reread**: update status `phase=read`.
 
 ## Step 6: Bounded Loop Guard
-If `cycle_iteration > 3` for same chapter: print block message — "max 3 iterations
+If `cycle_count > 3` for same chapter: print block message — "max 3 iterations
 reached without Mastery" — and halt, awaiting learner to adjust push-tactics or bar.
 </Steps>

--- a/tests/phase-6/default-status-shape.test.mjs
+++ b/tests/phase-6/default-status-shape.test.mjs
@@ -1,0 +1,43 @@
+/**
+ * Phase 6 — Regression test for issue #10: DEFAULT_STATUS.course_state shape
+ *
+ * Locks the canonical course_state schema to prevent terminology drift from
+ * silently returning. Issue #8 fixed a bug where hook mutators wrote a
+ * non-schema `cycle_iteration` field into course_state. Issue #10 cleaned
+ * up the terminology residue. This test keeps both closed.
+ *
+ * Contract:
+ *   - DEFAULT_STATUS.course_state.cycle_count must exist and be an integer
+ *   - DEFAULT_STATUS.course_state.cycle_iteration must NOT exist
+ *     (cycle_iteration is a verdict-payload field, not a course_state field)
+ */
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { DEFAULT_STATUS } from '../../hooks/lib/state.mjs';
+
+test('DEFAULT_STATUS.course_state exposes cycle_count (canonical field)', () => {
+  const cs = DEFAULT_STATUS.course_state;
+  assert.ok(cs, 'DEFAULT_STATUS must have a course_state object');
+  assert.ok(
+    Object.prototype.hasOwnProperty.call(cs, 'cycle_count'),
+    'course_state must have cycle_count key'
+  );
+  assert.ok(
+    Number.isInteger(cs.cycle_count),
+    `course_state.cycle_count must be an integer; got ${typeof cs.cycle_count}`
+  );
+  assert.ok(
+    cs.cycle_count >= 0,
+    `course_state.cycle_count must be >= 0; got ${cs.cycle_count}`
+  );
+});
+
+test('DEFAULT_STATUS.course_state does NOT contain stray cycle_iteration', () => {
+  const cs = DEFAULT_STATUS.course_state;
+  assert.equal(
+    Object.prototype.hasOwnProperty.call(cs, 'cycle_iteration'),
+    false,
+    'course_state must not carry cycle_iteration; that name belongs to verdict payload (schemas/verdict.mjs), not course_state'
+  );
+});

--- a/tests/phase-6/hook-libs.test.mjs
+++ b/tests/phase-6/hook-libs.test.mjs
@@ -166,13 +166,13 @@ test('should accept new sig, run updater, and return advanced:true when sig is n
     course_state: {
       last_advance_sig: null,
       current_phase: 'discuss',
-      cycle_iteration: 1,
+      cycle_count: 1,
     },
   };
 
   // Act
   const result = advanceIfNewSig(status, sig, (s) => {
-    s.course_state.cycle_iteration += 1;
+    s.course_state.cycle_count += 1;
     s.course_state.current_phase = 'idle';
   });
 
@@ -181,8 +181,8 @@ test('should accept new sig, run updater, and return advanced:true when sig is n
     'advanceIfNewSig must return advanced:true when sig is novel (different from stored)');
   assert.equal(result.status.course_state.last_advance_sig, sig,
     'returned status must have last_advance_sig set to the new sig');
-  assert.equal(result.status.course_state.cycle_iteration, 2,
-    'mutator must have been applied — cycle_iteration must have incremented');
+  assert.equal(result.status.course_state.cycle_count, 2,
+    'mutator must have been applied — cycle_count must have incremented');
   assert.equal(result.status.course_state.current_phase, 'idle',
     'mutator must have been applied — current_phase must be "idle"');
 });
@@ -196,7 +196,7 @@ test('should reject sig and return advanced:false with reason sig_match when sig
     course_state: {
       last_advance_sig: sig,   // sig already recorded — simulates second hook fire
       current_phase: 'idle',
-      cycle_iteration: 2,
+      cycle_count: 2,
     },
   };
   let mutatorCalled = false;
@@ -213,8 +213,8 @@ test('should reject sig and return advanced:false with reason sig_match when sig
     'reason field must be "sig_match" to distinguish idempotent no-op from other failures');
   assert.equal(mutatorCalled, false,
     'mutator must NOT be invoked on a sig_match no-op');
-  // Assert — status is returned unchanged (cycle_iteration still 2)
-  assert.equal(result.status.course_state.cycle_iteration, 2,
+  // Assert — status is returned unchanged (cycle_count still 2)
+  assert.equal(result.status.course_state.cycle_count, 2,
     'status must be unchanged when sig matches');
 });
 
@@ -228,16 +228,16 @@ test('should return the current state and advanced:false when called concurrentl
 
   // First call — status has null sig (fresh)
   const initialStatus = {
-    course_state: { last_advance_sig: null, cycle_iteration: 1, current_phase: 'discuss' },
+    course_state: { last_advance_sig: null, cycle_count: 1, current_phase: 'discuss' },
   };
   const first = advanceIfNewSig(initialStatus, sig, (s) => {
-    s.course_state.cycle_iteration += 1;
+    s.course_state.cycle_count += 1;
   });
   assert.equal(first.advanced, true, 'first call must advance');
 
   // Second call — uses the status returned by the first call (already has the sig)
   const second = advanceIfNewSig(first.status, sig, (s) => {
-    s.course_state.cycle_iteration += 1;  // must NOT run
+    s.course_state.cycle_count += 1;  // must NOT run
   });
 
   // Assert — second call is a no-op
@@ -245,8 +245,8 @@ test('should return the current state and advanced:false when called concurrentl
     'second call with same sig must return advanced:false (serializable idempotency)');
   assert.equal(second.reason, 'sig_match',
     'reason must be "sig_match" for the duplicate call');
-  assert.equal(second.status.course_state.cycle_iteration, 2,
-    'cycle_iteration must remain at 2 — second mutator must not have fired');
+  assert.equal(second.status.course_state.cycle_count, 2,
+    'cycle_count must remain at 2 — second mutator must not have fired');
 });
 
 // ---------------------------------------------------------------------------
@@ -336,7 +336,7 @@ test('should detect cycle when current_phase is not idle and last_advance_sig is
     course_state: {
       current_phase: 'discuss',
       last_advance_sig: 'evaluator:verdict.json:1713261600000',
-      cycle_iteration: 2,
+      cycle_count: 2,
     },
   };
 
@@ -379,7 +379,7 @@ test('should return inCycle:false when current_phase is idle', async () => {
     course_state: {
       current_phase: 'idle',
       last_advance_sig: null,
-      cycle_iteration: 0,
+      cycle_count: 0,
     },
   };
 

--- a/tests/phase-6/session-end.test.mjs
+++ b/tests/phase-6/session-end.test.mjs
@@ -91,7 +91,7 @@ function seedStatusJson(projectDir, statusOverrides = {}) {
       current_course: 'tdd-fundamentals',
       current_chapter: 'chapter-3-mocking',
       current_phase: 'discuss',
-      cycle_iteration: 2,
+      cycle_count: 2,
       last_advance_sig: null,
     },
     session: {
@@ -167,7 +167,7 @@ test('should append a timestamped session entry to wiki/log.md when the file exi
         current_course: 'tdd-fundamentals',
         current_chapter: 'chapter-3-mocking',
         current_phase: 'discuss',
-        cycle_iteration: 2,
+        cycle_count: 2,
         last_advance_sig: null,
       },
       session: {

--- a/tests/phase-6/session-start.test.mjs
+++ b/tests/phase-6/session-start.test.mjs
@@ -226,7 +226,7 @@ test('should include active course and phase in systemMessage when status has an
         current_course: 'tdd-fundamentals',
         current_chapter: 'chapter-3-mocking',
         current_phase: 'discuss',
-        cycle_iteration: 2,
+        cycle_count: 2,
         last_advance_sig: 'evaluator:verdict.json:1713261600000',
       },
       session: { total_sessions: 5, last_start: new Date().toISOString() },

--- a/tests/phase-6/user-prompt-submit.test.mjs
+++ b/tests/phase-6/user-prompt-submit.test.mjs
@@ -86,7 +86,7 @@ function makeTempProjectWithStatus(phase, overrides = {}) {
       current_course: 'tdd-fundamentals',
       current_chapter: 'chapter-3-mocking',
       current_phase: phase,
-      cycle_iteration: 2,
+      cycle_count: 2,
       last_advance_sig: phase === 'idle' ? null : 'evaluator:verdict.json:1713261600000',
       ...overrides,
     },


### PR DESCRIPTION
## Summary

Follow-up cleanup to PR #9 (issues #6/#7/#8). The runtime bug is already fixed — `hooks/stop.mjs`, `hooks/subagent-stop.mjs`, `state.mjs` DEFAULT_STATUS, and `stop-hooks.test.mjs` all use `course_state.cycle_count` now. This PR removes residual \`cycle_iteration\` references that were left behind in skill docs, adjacent tests, and helper comments.

### What's distinct here

\`cycle_iteration\` is still valid — but **only as a verdict payload field** defined by \`schemas/verdict.mjs\` (the ordinal of the cycle that produced the verdict, stamped at emission time). This PR preserves that usage and adds a clarifying NOTE in the verdict schema header so future contributors don't conflate it with \`course_state.cycle_count\` (the persisted counter in status.json).

## Changes

**Renamed (course_state context only):**
- \`skills/verdict/SKILL.md\` — 3 references (bounded loop threshold, rediscuss update, cap message)
- \`tests/phase-6/hook-libs.test.mjs\` — seeds + asserts in advanceIfNewSig tests
- \`tests/phase-6/user-prompt-submit.test.mjs\` — 1 seed
- \`tests/phase-6/session-start.test.mjs\` — 1 seed
- \`tests/phase-6/session-end.test.mjs\` — 2 seeds

**Added:**
- \`mcp-server/schemas/verdict.mjs\` — clarifying NOTE in calling-spec header distinguishing the two fields, citing issues #8/#10
- \`tests/phase-6/default-status-shape.test.mjs\` — NEW regression test that locks DEFAULT_STATUS.course_state shape: asserts \`cycle_count\` exists + \`cycle_iteration\` does NOT. Prevents silent re-drift.

**Deliberately untouched** (verdict payload — legitimate):
- \`mcp-server/schemas/verdict.mjs\` field definitions + \`handlers/verdict-handler.js\`
- \`tests/phase-3/verdict-handler.test.mjs\`, \`schemas.test.mjs\`
- \`agents/evaluator.md\`, \`dashboard/render-course.mjs\`
- \`tests/e2e/mock-agents.mjs\` evaluator mock (returns verdict payload)

## Test plan

- [x] Full suite: **311/311 passing** (was 309 + 2 new regression tests in default-status-shape.test.mjs)
- [x] Grep audit: zero \`course_state.cycle_iteration\` references remain in production + test seeds
- [x] Verdict payload \`cycle_iteration\` references preserved and documented

## Out of scope

- \`docs/plans/v0.1/*.md\` — historical plan documents, low priority, can stay as a record of the original design intent

🤖 Generated with [Claude Code](https://claude.com/claude-code)