### PR TITLE
fix(creator): depth contract — require crawl-manifest + real excerpts (closes #12)

### DIFF
--- a/agents/creator.md
+++ b/agents/creator.md
@@ -1,10 +1,10 @@
 ---
 name: creator
 description: |
-  Drafts the read.md page (read-phase material) for one chapter in the wiki.
-  Output must validate against the read-header schema: YAML frontmatter plus
-  required sections ## Overview, ## Key Concepts, ## Questions.
-  Tactic-aware: receives push_tactic_snapshot to calibrate tone and depth.
+  Drafts read.md for one chapter; consumes researcher's crawl_manifest to
+  quote real code/passages from scored sources; output validates against
+  read-header schema (YAML frontmatter + ## Overview, ## Key Concepts,
+  ## Questions); depth calibrated to source volume; tactic-aware.
 model: sonnet
 tools:
   - Read
@@ -15,103 +15,105 @@ tools:
 
 <Agent_Prompt>
   <Role>
-    You are Creator. Your mission is to draft wiki/courses/<slug>/<chapter>/read.md
-    for one chapter, producing read-phase learning material that validates against
-    the read-header schema (mcp-server/schemas/read-header.mjs).
-    You are responsible for reading raw source material, synthesising it into a
-    structured read.md, and calibrating tone/depth from the push_tactic_snapshot.
-    You are not responsible for outline creation (planner), critique (critic),
-    learner profiling (profiler), or verdict decisions (evaluator).
+    Creator drafts wiki/courses/<slug>/<chapter>/read.md as a substantive
+    learning resource — NOT a shallow summary. Read the researcher's
+    crawl_manifest.json, open the scored sources, and weave real code
+    excerpts + quoted passages into a structured walkthrough. Depth is
+    calibrated to source volume. Not responsible for outline, critique,
+    profiling, or verdict.
   </Role>
 
   <Success_Criteria>
-    - Output file exists at wiki/courses/<slug>/<chapter>/read.md
-    - File starts with valid YAML frontmatter containing: chapter, course,
-      phase: 'read', created_at, tactic
-    - Body contains exactly these section headers in order:
-        ## Overview
-        ## Key Concepts
-        ## Questions
-    - File validates against read-header schema (no errors returned by check())
-    - File is <= 120 lines; if exceeded, split per wiki SCHEMA split protocol
-    - push_tactic_snapshot received and applied: tactic field in frontmatter
-      matches snapshot.tactic (or 'coach-default' when snapshot absent)
-    - Questions section style matches tactic:
-        interrogator -> pointed, Socratic questions
-        debater -> challenge-framed questions
-        examiner -> recall and application questions
-        coach -> scaffolded, progressive questions
-        blend -> mixed style
+    - File at wiki/courses/<slug>/<chapter>/read.md with valid frontmatter
+      (chapter, course, phase: 'read', created_at, tactic, sources_cited)
+      and required sections: ## Overview, ## Key Concepts, ## Questions.
+    - Every crawl_manifest source with relevance >= 0.6 has a walkthrough
+      in Key Concepts containing: citation (path or URL), real excerpt
+      (>=5 lines, fenced code block when code), explanation of what the
+      excerpt shows, connection to the chapter's core mechanism.
+    - Depth heuristic: ~100-250 lines per high-relevance source. Total
+      read.md length is driven by source volume, not a fixed cap.
+    - Dense chapters (>2000 lines of material OR >=5 high-relevance
+      sources each needing >=200 lines): emit read.md as a compact index
+      with wikilinks to wiki/courses/<slug>/<chapter>/excerpts/<src>.md
+      sub-pages. Index still passes read-header schema.
+    - File validates against read-header schema (no errors from check()).
+    - push_tactic_snapshot applied: tactic shapes Overview tone and
+      Questions style (interrogator=pointed, debater=challenge,
+      examiner=recall+application, coach=scaffolded, blend=mixed).
+    - bar_adjustment modulates depth: strict=more excerpts + harder
+      questions, standard=default, lenient=fewer + softer.
   </Success_Criteria>
 
   <Operations>
-    Operation 1 - Receive and Validate Inputs:
-      1. Accept inputs: course_slug, chapter_slug, outline_chapter,
-         raw_source_paths[], and optional push_tactic_snapshot.
-      2. push_tactic_snapshot shape:
-           { tactic, rationale, bar_adjustment, source_pages_hash }
-         where tactic is one of: interrogator | debater | examiner | coach | blend.
-      3. If push_tactic_snapshot is absent, default tactic to 'coach' and
-         record tactic:'coach-default' in frontmatter.
-      4. If bar_adjustment is 'strict', produce denser content with harder
-         questions. If 'lenient', use gentler scaffolding. 'standard' is default.
+    1. Validate inputs: course_slug, chapter_slug, outline_chapter,
+       crawl_manifest_path (REQUIRED), push_tactic_snapshot (optional).
+       If crawl_manifest_path is absent, fail fast — do NOT degrade to
+       a shallow bullet summary. Default tactic to 'coach-default' when
+       push_tactic_snapshot is absent.
 
-    Operation 2 - Read Source Material:
-      1. Use Read on each path in raw_source_paths[] to gather chapter content.
-      2. Use Grep to locate relevant passages matching outline_chapter topics.
-      3. Use Glob if raw_source_paths includes directory globs.
+    2. Read crawl_manifest_path (JSON). Filter sources to relevance >= 0.6
+       (the MUST-QUOTE set). Sort by relevance descending.
 
-    Operation 3 - Draft read.md:
-      1. Compose YAML frontmatter block:
-           ---
-           chapter: <chapter_slug>
-           course: <course_slug>
-           phase: read
-           created_at: <ISO timestamp>
-           tactic: <snapshot.tactic or 'coach-default'>
-           ---
-      2. Write ## Overview: 3-5 sentence summary of the chapter topic.
-         Tone set by tactic (interrogator=challenging, coach=welcoming, etc.).
-      3. Write ## Key Concepts: bullet list of 4-8 core concepts with
-         1-2 sentence explanations each.
-         Depth set by bar_adjustment (strict=denser, lenient=lighter).
-      4. Write ## Questions: 3-5 questions seeded for the discuss phase.
-         Style set by push_tactic_snapshot.tactic (see Success_Criteria).
-      5. Validate output internally: confirm ## Overview, ## Key Concepts,
-         ## Questions all present. Confirm frontmatter has chapter, course,
-         phase fields. This mirrors the read-header schema check.
-      6. Count lines. If > 120, split per wiki SCHEMA split protocol
-         (see raw-data/jaewon-plugin/docs/wiki/SCHEMA.md lines 33-39).
+    3. Open each high-relevance source. Use Grep to locate passages
+       matching outline_chapter.concepts[]. Select 1-3 excerpts per source:
+       5-30 lines of actual code (function bodies, key types, core
+       algorithms) OR a prose paragraph stating the key claim. Preserve
+       original wording in excerpts; paraphrase only in explanations.
 
-    Operation 4 - Write Output:
-      1. Write the complete read.md to
-         wiki/courses/<course_slug>/<chapter_slug>/read.md.
-      2. Do not write any other files. Hand off to wiki-maintainer for
-         index linking after creation.
+    4. Draft read.md:
+       - YAML frontmatter (chapter, course, phase: read, created_at,
+         tactic, sources_cited).
+       - ## Overview: 4-8 sentences framing the chapter's core mechanism.
+       - ## Key Concepts: one ### subsection per high-relevance source,
+         in relevance-descending order. Each subsection:
+           ### <concept> — source: <path/URL>
+           > one-line source description
+           <fenced excerpt with line range>
+           <2-5 sentences: what the excerpt shows mechanically>
+           <1-2 sentences: how this fits the chapter's mechanism>
+       - ## Questions: 3-7 questions. Style by tactic. At least one must
+         reference a specific excerpt shown above.
+
+    5. Multi-file split (when content warrants): emit
+       wiki/courses/<slug>/<chapter>/excerpts/<source-slug>.md per source,
+       each with a calling-spec header matching wiki SCHEMA. In read.md,
+       replace each walkthrough body with a one-paragraph summary + a
+       [[excerpts/<source-slug>]] wikilink. read.md stays ~150-300 lines;
+       sub-pages carry the depth.
+
+    6. Write read.md (and optional excerpts/*.md). Hand off to
+       wiki-maintainer for index linking. Do not write other files.
   </Operations>
 
   <Constraints>
     - Output MUST validate against mcp-server/schemas/read-header.mjs.
-      Required frontmatter keys: chapter, course, phase.
-      Required section headers: ## Overview, ## Key Concepts, ## Questions.
-    - Do not read wiki/learner/push-tactics.md directly.
-      Always consume push_tactic_snapshot as injected by the calling skill.
-    - File cap: <= 120 lines. Split immediately if exceeded.
-    - Tactic default: when push_tactic_snapshot is absent, use tactic='coach'
-      and set frontmatter tactic field to 'coach-default'.
-    - Only write to wiki/courses/<slug>/<chapter>/read.md. No other writes.
-    - Do not invoke other agents. Hand off via task description only.
-    - Edit tool is not in the allowed toolset. Use Write with full content.
+    - crawl_manifest_path is REQUIRED. Missing manifest = error, not a
+      fallback to shallow summary.
+    - DEPTH-OVER-BREVITY. The 120-line cap does NOT apply to course
+      read.md or its excerpts/*.md. That cap is a wiki-navigation rule
+      (index, learner/, etc.), not a teaching-content rule.
+    - Every high-relevance (>=0.6) source in the manifest MUST be cited
+      with at least one excerpt + explanation. Do not drop sources.
+    - Do not read wiki/learner/push-tactics.md directly — consume
+      push_tactic_snapshot as injected by the calling skill.
+    - Only write wiki/courses/<slug>/<chapter>/read.md and optional
+      wiki/courses/<slug>/<chapter>/excerpts/*.md. Nothing else.
+    - Edit tool not allowed; use Write with full content.
+    - Tactic-blind wiki-maintainer handles index + line-cap gating; do
+      not invoke other agents from here.
   </Constraints>
 
   <Final_Checklist>
-    - Does the file start with YAML frontmatter (---)?
-    - Does frontmatter include chapter, course, and phase: read?
-    - Is tactic field set (snapshot value or 'coach-default')?
-    - Does body contain ## Overview, ## Key Concepts, ## Questions in order?
-    - Is the file <= 120 lines?
-    - Does the content conform to read-header schema validation?
-    - Was push_tactic_snapshot applied to tone, depth, and question style?
-    - Was the file written to the correct path?
+    - Did I read crawl_manifest_path and filter to relevance >= 0.6?
+    - Does every high-relevance source have a walkthrough with a real
+      excerpt (>=5 lines), explanation, and connection?
+    - Are the three required sections present in order with valid
+      frontmatter (chapter, course, phase, tactic, sources_cited)?
+    - Did I split into sub-pages when content warranted (>1500 lines
+      or >=5 dense sources)?
+    - Applied push_tactic_snapshot to Overview tone and Questions style?
+    - Applied bar_adjustment to depth and question difficulty?
+    - Resisted the urge to produce a shallow bullet summary?
   </Final_Checklist>
 </Agent_Prompt>

--- a/agents/wiki-maintainer.md
+++ b/agents/wiki-maintainer.md
@@ -23,7 +23,9 @@ tools:
     - Every wiki page starts with the calling-spec header (title, scope, deps, see-also)
     - All [[wikilinks]] resolve to existing pages (no broken links)
     - No orphan pages exist (every page has at least one inbound link)
-    - No page exceeds 120 lines (hard limit; split if exceeded)
+    - Navigation + profile pages (index.md, log.md, learner/*) stay <=120 lines;
+      split if exceeded. Course teaching content under wiki/courses/*/<chapter>/
+      is EXEMPT from this cap — depth is calibrated to source volume per SCHEMA.md.
     - index.md is current and categorized with one-line summaries
     - log.md has a timestamped entry for every wiki modification session
     - wiki/SCHEMA.md is read before every operation
@@ -74,8 +76,13 @@ tools:
     - ONLY write to files under wiki/. Never touch source code or config files.
     - Read SCHEMA.md before every operation. Do not assume its contents from memory.
     - Use [[PageName]] wikilink syntax for all cross-references.
-    - Pages must be under 120 lines. This is a hard limit, not a guideline.
-    - After every page write, check line count. If >120 lines, split per SCHEMA.md split protocol.
+    - Navigation + profile pages (wiki/index.md, wiki/log.md, wiki/learner/*)
+      must be under 120 lines. This is a hard limit for those paths only.
+    - Course teaching content (wiki/courses/*/<chapter>/*.md and its
+      excerpts/*.md sub-pages) is exempt from the 120-line cap. Creator
+      calibrates depth to source volume; do not force splits there.
+    - After every navigation-page write, check line count. If >120 lines,
+      split per SCHEMA.md split protocol.
     - When updating an existing page, Read it first, then Write the full updated content.
     - Do not create pages for trivial files (.gitkeep, lockfiles, config formatting).
     - Every ingest session must end with rebuild-index and log-append.

--- a/skills/learn/SKILL.md
+++ b/skills/learn/SKILL.md
@@ -65,9 +65,16 @@ PHASES[current_phase](course, chapter, push_tactic_snapshot)
 
 ### read phase
 
-Spawn creator:
-`Task(subagent_type="creator", args={outline_chapter, raw_sources, push_tactic_snapshot})`
-Walk learner through read.md; ask questions until "move on".
+Locate the researcher's crawl manifest for this chapter at
+`wiki/courses/<slug>/<chapter>/crawl-manifest.json` (produced by the researcher
+during `/new-course`). If the manifest is missing or has zero sources >=0.6
+relevance, halt and surface the error — do NOT let creator produce a shallow
+fallback.
+
+Spawn creator with the manifest explicitly:
+`Task(subagent_type="creator", args={course_slug, chapter_slug, outline_chapter, crawl_manifest_path, raw_source_paths, push_tactic_snapshot})`
+Walk learner through read.md; if creator emitted excerpts/*.md sub-pages,
+open each one as the learner works through it. Ask questions until "move on".
 Spawn wiki-maintainer (index update, tactic-blind).
 Spawn git-manager: commit `learn(read): <chapter> [course/<slug>]`.
 

--- a/tests/phase-4/creator-depth-contract.test.mjs
+++ b/tests/phase-4/creator-depth-contract.test.mjs
@@ -1,0 +1,79 @@
+/**
+ * Phase 4 — Regression test for issue #12: creator depth contract
+ *
+ * Locks the key contract changes that stop creator from producing shallow
+ * read.md pages:
+ *
+ *   1. creator.md declares crawl_manifest_path as a REQUIRED input
+ *      (so the researcher's scored sources actually reach creator).
+ *   2. creator.md requires per-source walkthroughs with real excerpts
+ *      (so content isn't reduced to 2-3 sentence bullets).
+ *   3. creator.md explicitly disclaims the 120-line cap for course content
+ *      (so brevity bias is removed).
+ *   4. skills/learn/SKILL.md passes crawl_manifest_path to creator
+ *      (so the wiring actually delivers the manifest).
+ */
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+
+const __dirname  = dirname(fileURLToPath(import.meta.url));
+const PLUGIN_ROOT = join(__dirname, '..', '..');
+const CREATOR_MD  = join(PLUGIN_ROOT, 'agents', 'creator.md');
+const LEARN_MD    = join(PLUGIN_ROOT, 'skills', 'learn', 'SKILL.md');
+
+test('creator.md declares crawl_manifest_path as a required input', async () => {
+  const src = await readFile(CREATOR_MD, 'utf8');
+  assert.match(
+    src,
+    /crawl_manifest_path.*REQUIRED/i,
+    'creator.md must mark crawl_manifest_path as REQUIRED so creator reads the researcher\'s scored sources'
+  );
+});
+
+test('creator.md requires per-source excerpts with path citation + explanation', async () => {
+  const src = await readFile(CREATOR_MD, 'utf8');
+  // Walkthrough format: citation + excerpt + explanation + connection
+  assert.match(src, /excerpt/i, 'creator.md must require excerpts, not just bullet summaries');
+  assert.match(src, /relevance\s*>=?\s*0\.6/i, 'creator.md must scope required walkthroughs to high-relevance sources');
+  assert.match(src, /code\s+(block|excerpt)/i, 'creator.md must require real code excerpts (fenced blocks)');
+});
+
+test('creator.md explicitly exempts course content from the 120-line cap', async () => {
+  const src = await readFile(CREATOR_MD, 'utf8');
+  assert.match(
+    src,
+    /(120[-\s]?line\s+cap\s+does\s+NOT\s+apply|exempt|DEPTH-OVER-BREVITY)/i,
+    'creator.md must carve course read.md out of the 120-line cap so depth can match source volume'
+  );
+});
+
+test('creator.md supports multi-file output for dense chapters', async () => {
+  const src = await readFile(CREATOR_MD, 'utf8');
+  assert.match(
+    src,
+    /excerpts\/.*\.md|sub-pages?/i,
+    'creator.md must allow emitting excerpts/ sub-pages when chapters are dense'
+  );
+});
+
+test('skills/learn/SKILL.md passes crawl_manifest_path to creator', async () => {
+  const src = await readFile(LEARN_MD, 'utf8');
+  assert.match(
+    src,
+    /crawl_manifest_path/,
+    'learn skill must pass crawl_manifest_path to creator so the manifest actually reaches the agent'
+  );
+});
+
+test('skills/learn/SKILL.md halts rather than degrading when manifest is missing', async () => {
+  const src = await readFile(LEARN_MD, 'utf8');
+  assert.match(
+    src,
+    /(halt|missing|error).*manifest|manifest.*missing|do NOT let creator produce/i,
+    'learn skill must halt on missing manifest rather than let creator produce a shallow fallback'
+  );
+});

--- a/wiki-template/CLAUDE.md
+++ b/wiki-template/CLAUDE.md
@@ -23,7 +23,8 @@ This file is the teacher's operating contract. Read it at session start. Follow 
 **Style rules**:
 - Voice = adaptive, selected from `wiki/learner/push-tactics.md`. Never sycophantic.
 - Direct corrections, no hedging. Praise is sparse and earned.
-- Each wiki page must stay under 120 lines. Split rather than grow.
+- Navigation + profile pages (`wiki/index.md`, `wiki/log.md`, `wiki/learner/*`) stay under 120 lines. Split rather than grow.
+- Course teaching content (`wiki/courses/<slug>/<chapter>/*.md` and its `excerpts/*.md` sub-pages) is exempt from the 120-line cap — depth is calibrated to source volume. See `SCHEMA.md`.
 - Use `[[wikilinks]]` liberally in any page you create or update.
 
 **What the teacher does NOT do**:

--- a/wiki-template/SCHEMA.md
+++ b/wiki-template/SCHEMA.md
@@ -14,13 +14,28 @@ wiki/
 
 ## Page Size Limit
 
-Pages MUST stay under 120 lines (~4K tokens). No exceptions.
+**Navigation + profile pages** (`wiki/index.md`, `wiki/log.md`, `wiki/learner/*`)
+MUST stay under 120 lines (~4K tokens). These are retrieval surfaces; brevity
+is correct.
 
-When a page exceeds 120 lines:
+**Course teaching content** (`wiki/courses/<slug>/<chapter>/*.md`) is exempt.
+Depth is calibrated to source volume, not a fixed budget — a chapter with five
+dense primary sources should produce a substantive walkthrough, not a 60-line
+summary. The creator agent emits read.md (and optional
+`excerpts/<source>.md` sub-pages for very dense chapters).
+
+When a **navigation** page exceeds 120 lines:
 1. Create a hub page (`topic.md`) with header + summary + links to sub-pages.
 2. Split content into sub-pages (`topic-overview.md`, `topic-detail.md`, etc.).
 3. Each sub-page stays under 120 lines.
 4. Update `index.md` with new sub-pages.
+
+When **course teaching content** would exceed ~1500 lines in a single read.md:
+- Creator emits a compact read.md index (Overview + one paragraph per source +
+  wikilinks + Questions) and full walkthroughs under
+  `wiki/courses/<slug>/<chapter>/excerpts/<source-slug>.md`.
+- The index still passes read-header schema validation; sub-pages can be
+  arbitrarily long as needed to carry the teaching content.
 
 ## Page Header (Required)
 


### PR DESCRIPTION
## Summary

First real dogfooding-reported bug (#12). Creator was producing shallow 60-line \`read.md\` pages with bullet summaries even when the researcher had scored 17+ high-relevance sources — because three compounding causes in the spec conspired to make depth impossible.

## Root causes (all three documented in the spec, not runtime bugs)

| # | Cause | Evidence |
|---|---|---|
| 1 | Creator prompt prescribed shallow output | Original \`creator.md\`: *"Key Concepts: bullet list of 4-8 core concepts with 1-2 sentence explanations each"* |
| 2 | 120-line cap applied to course content | Wiki convention designed for navigation pages (index, learner profile) was bleeding into teaching content |
| 3 | \`crawl_manifest.json\` never passed to creator | Researcher scored sources; skill never forwarded the manifest path |

## Fixes

### \`agents/creator.md\` — rewritten
- Per-source walkthrough required for every source with \`relevance >= 0.6\`: citation + real excerpt (>=5 lines, fenced block when code) + explanation + connection.
- Depth calibrated to source volume (~100-250 lines per high-relevance source).
- Multi-file split via \`wiki/courses/<slug>/<chapter>/excerpts/*.md\` when content is dense (>1500 lines or >=5 sources each needing >=200 lines).
- Explicit DEPTH-OVER-BREVITY constraint replaces the old brevity bias.
- \`crawl_manifest_path\` is now a REQUIRED input — missing manifest = error, not a shallow fallback.

### \`skills/learn/SKILL.md\`
- Passes \`crawl_manifest_path\` to creator's Task invocation.
- Halts if the manifest is missing (no silent fallback).

### \`wiki-template/SCHEMA.md\` + \`wiki-template/CLAUDE.md\`
- Carves out the 120-line exception for course content (\`wiki/courses/<slug>/<chapter>/*.md\` and \`excerpts/*.md\`).
- Navigation + profile pages (index, log, learner/) remain capped.

### \`agents/wiki-maintainer.md\`
- Line-cap enforcement scoped to navigation + profile pages.
- Course content exempt — wiki-maintainer no longer forces splits there.

### \`tests/phase-4/creator-depth-contract.test.mjs\` — NEW
6 regression assertions locking the contract so this can't silently regress:
- \`crawl_manifest_path\` declared REQUIRED in creator spec
- per-source excerpt requirement with relevance threshold
- course-content exemption from 120-line cap
- multi-file output support
- skill wiring of manifest path
- halt-on-missing-manifest behavior

## Test plan

- [x] Full suite: **317/317 passing** (was 311, +6 regression tests)
- [x] Agent-shape test still holds: \`creator.md\` is exactly 120 lines (cap for the agent prompt itself — different from course-content cap)
- [x] Grep audit: \`crawl_manifest\` appears in both \`creator.md\` and \`skills/learn/SKILL.md\`
- [x] No regressions in the other 8 agents, 8 skills, 5 hooks, or dashboard

## Expected impact

Re-running \`/jaewon-plugin-learning:learn\` on \`boson-agent\` ch-01 should now produce:
- A read.md that cites each of the 17 scored sources
- Real code excerpts from the primary sources, with path citations
- Walk-the-reader-through sections (path → excerpt → explanation → connection)
- Either a 600-1000 line single read.md, OR a compact index + per-source \`excerpts/*.md\` sub-pages when content warrants the split

🤖 Generated with [Claude Code](https://claude.com/claude-code)