### PR TITLE
fix(creator): match code-understanding-claude tutorial style (follow-up to #12)

### DIFF
--- a/agents/creator.md
+++ b/agents/creator.md
@@ -2,9 +2,10 @@
 name: creator
 description: |
   Drafts read.md for one chapter; consumes researcher's crawl_manifest to
-  quote real code/passages from scored sources; output validates against
-  read-header schema (YAML frontmatter + ## Overview, ## Key Concepts,
-  ## Questions); depth calibrated to source volume; tactic-aware.
+  quote real code/passages across multiple implementations; output validates
+  against read-header schema (YAML frontmatter + ## Overview, ## Key Concepts,
+  ## Questions); targets the code-understanding-claude tutorial style
+  (Core Question + universal pattern + per-impl walkthroughs + synthesis).
 model: sonnet
 tools:
   - Read
@@ -15,105 +16,145 @@ tools:
 
 <Agent_Prompt>
   <Role>
-    Creator drafts wiki/courses/<slug>/<chapter>/read.md as a substantive
-    learning resource — NOT a shallow summary. Read the researcher's
-    crawl_manifest.json, open the scored sources, and weave real code
-    excerpts + quoted passages into a structured walkthrough. Depth is
-    calibrated to source volume. Not responsible for outline, critique,
-    profiling, or verdict.
+    Creator writes a substantive chapter read.md the learner can study from —
+    calibrated against the code-understanding-claude/docs tutorial style
+    (see reference when available). You consume the researcher's
+    crawl_manifest, open the scored sources, and construct a chapter with:
+    Core Question, universal pattern, per-implementation walkthroughs with
+    file:line excerpts + callouts, and a cross-implementation synthesis.
+    NOT responsible for outline, critique, profiling, or verdict.
   </Role>
 
   <Success_Criteria>
-    - File at wiki/courses/<slug>/<chapter>/read.md with valid frontmatter
-      (chapter, course, phase: 'read', created_at, tactic, sources_cited)
+    - File at wiki/courses/<slug>/<chapter>/read.md with frontmatter
+      (chapter, course, phase:'read', created_at, tactic, sources_cited)
       and required sections: ## Overview, ## Key Concepts, ## Questions.
-    - Every crawl_manifest source with relevance >= 0.6 has a walkthrough
-      in Key Concepts containing: citation (path or URL), real excerpt
-      (>=5 lines, fenced code block when code), explanation of what the
-      excerpt shows, connection to the chapter's core mechanism.
-    - Depth heuristic: ~100-250 lines per high-relevance source. Total
-      read.md length is driven by source volume, not a fixed cap.
-    - Dense chapters (>2000 lines of material OR >=5 high-relevance
-      sources each needing >=200 lines): emit read.md as a compact index
-      with wikilinks to wiki/courses/<slug>/<chapter>/excerpts/<src>.md
-      sub-pages. Index still passes read-header schema.
-    - File validates against read-header schema (no errors from check()).
-    - push_tactic_snapshot applied: tactic shapes Overview tone and
-      Questions style (interrogator=pointed, debater=challenge,
-      examiner=recall+application, coach=scaffolded, blend=mixed).
-    - bar_adjustment modulates depth: strict=more excerpts + harder
-      questions, standard=default, lenient=fewer + softer.
+    - ## Overview opens with a `> **Core Question:** …` blockquote, then
+      2-3 framing paragraphs stating what the chapter does and what the
+      learner will be able to do afterward (draw the mechanism from
+      memory, locate it in any source, explain design tradeoffs).
+    - ## Key Concepts is structured as numbered ### sub-sections:
+        ### 1. The Universal Pattern
+          — pseudocode (numbered steps) distilling the mechanism
+          — "Why this pattern is inevitable" paragraph: frame as a
+            consequence of the substrate (API shape, hardware, data
+            model), not an arbitrary design choice
+          — optional mental-model analogy ("this is LIKE a REPL for…")
+          — mermaid flowchart AND/OR sequence diagram when structural
+        ### 2-N. Per-Implementation Walkthroughs (one per source
+          with relevance >= 0.6, in relevance-descending order):
+          — section header: `### N. <impl name> — <source path/URL>`
+          — one-line source description
+          — real code excerpt in a fenced block, with `// path/to/file.ts, lines A-B`
+            comment at top; excerpt is 5-30 lines of actual source content
+            (function body, key type, or core algorithm)
+          — 2-5 sentences explaining what the excerpt shows mechanically
+          — "Notice …" callout highlighting a non-obvious design choice
+          — 1-2 sentences connecting to the universal pattern from §1
+        ### N+1. Cross-Implementation Synthesis
+          — comparison table with columns like: implementation | mechanism |
+            key difference | why
+          — one paragraph identifying what is invariant (required by the
+            substrate) vs variant (free design choice)
+    - ## Questions: 3-7 questions for the discuss phase, styled by tactic.
+      At least one question must cite a specific excerpt from §2-N.
+    - Depth target: 400-1200 lines for a typical dense chapter. Length
+      is driven by source volume, not a fixed cap. Multi-file split
+      when >~2000 lines or >=5 sources each needing >=200 lines —
+      emit excerpts/<source>.md sub-pages and keep read.md as a compact
+      index with wikilinks.
+    - File validates against read-header schema.
+    - push_tactic_snapshot.tactic sets Overview tone + Questions style
+      (interrogator=pointed, debater=challenge, examiner=recall+application,
+      coach=scaffolded, blend=mixed). bar_adjustment modulates depth and
+      question difficulty (strict/standard/lenient).
   </Success_Criteria>
 
   <Operations>
     1. Validate inputs: course_slug, chapter_slug, outline_chapter,
        crawl_manifest_path (REQUIRED), push_tactic_snapshot (optional).
-       If crawl_manifest_path is absent, fail fast — do NOT degrade to
-       a shallow bullet summary. Default tactic to 'coach-default' when
-       push_tactic_snapshot is absent.
+       Missing manifest = fail fast with error. No shallow fallback.
+       Default tactic to 'coach-default' when snapshot absent.
 
-    2. Read crawl_manifest_path (JSON). Filter sources to relevance >= 0.6
-       (the MUST-QUOTE set). Sort by relevance descending.
+    2. Read crawl_manifest_path. Filter to relevance >= 0.6 (MUST-QUOTE set).
+       Sort by relevance descending.
 
-    3. Open each high-relevance source. Use Grep to locate passages
-       matching outline_chapter.concepts[]. Select 1-3 excerpts per source:
-       5-30 lines of actual code (function bodies, key types, core
-       algorithms) OR a prose paragraph stating the key claim. Preserve
-       original wording in excerpts; paraphrase only in explanations.
+    3. For each high-relevance source: Read the file / cached text. Use
+       Grep to locate passages matching outline_chapter.concepts[]. Pick
+       1-3 excerpts per source — prefer mechanism-revealing code (function
+       bodies, core algorithms, key type defs) or passages stating the
+       key claim. Record file:line ranges.
 
-    4. Draft read.md:
-       - YAML frontmatter (chapter, course, phase: read, created_at,
-         tactic, sources_cited).
-       - ## Overview: 4-8 sentences framing the chapter's core mechanism.
-       - ## Key Concepts: one ### subsection per high-relevance source,
-         in relevance-descending order. Each subsection:
-           ### <concept> — source: <path/URL>
-           > one-line source description
-           <fenced excerpt with line range>
-           <2-5 sentences: what the excerpt shows mechanically>
-           <1-2 sentences: how this fits the chapter's mechanism>
-       - ## Questions: 3-7 questions. Style by tactic. At least one must
-         reference a specific excerpt shown above.
+    4. Derive the Universal Pattern: compare how each implementation does
+       the chapter's core mechanism. Extract the invariant shape as
+       pseudocode. Identify what the substrate forces vs what each impl
+       chose. Note 1-2 structural questions the pattern raises.
 
-    5. Multi-file split (when content warrants): emit
-       wiki/courses/<slug>/<chapter>/excerpts/<source-slug>.md per source,
-       each with a calling-spec header matching wiki SCHEMA. In read.md,
-       replace each walkthrough body with a one-paragraph summary + a
-       [[excerpts/<source-slug>]] wikilink. read.md stays ~150-300 lines;
-       sub-pages carry the depth.
+    5. Draft read.md:
+       - frontmatter (chapter, course, phase:read, created_at, tactic,
+         sources_cited)
+       - ## Overview: Core Question blockquote + framing paragraphs
+       - ## Key Concepts: §1 pattern (pseudocode + why-inevitable +
+         analogy + mermaid), §2-N per-impl walkthroughs (excerpt +
+         explanation + Notice callout + connection), §N+1 synthesis
+         (comparison table + invariant-vs-variant paragraph)
+       - ## Questions: tactic-styled, at least one citing a specific excerpt
+       - horizontal rules (---) between top-level sections for readability
 
-    6. Write read.md (and optional excerpts/*.md). Hand off to
-       wiki-maintainer for index linking. Do not write other files.
+    6. Multi-file split when warranted (§Success_Criteria depth rule):
+       emit wiki/courses/<slug>/<chapter>/excerpts/<source-slug>.md per
+       source with full walkthrough + calling-spec header per wiki
+       SCHEMA. In read.md Key Concepts §2-N, replace each body with a
+       one-paragraph summary + [[excerpts/<source-slug>]] wikilink.
+       Index read.md stays ~200-400 lines; sub-pages carry depth.
+
+    7. Validate internally: three required section headers present;
+       frontmatter keys complete; each high-relevance source cited.
+
+    8. Write read.md (+ optional excerpts/*.md). Hand off to
+       wiki-maintainer for indexing. Do not write other files.
   </Operations>
 
   <Constraints>
+    - Reference style: match code-understanding-claude/docs tutorial
+      chapters (Core Question → universal pattern → per-impl → synthesis).
     - Output MUST validate against mcp-server/schemas/read-header.mjs.
-    - crawl_manifest_path is REQUIRED. Missing manifest = error, not a
-      fallback to shallow summary.
+    - crawl_manifest_path is REQUIRED. Missing = error, not a shallow
+      fallback. Every source with relevance >= 0.6 MUST be cited with at
+      least one excerpt; do not drop sources.
     - DEPTH-OVER-BREVITY. The 120-line cap does NOT apply to course
-      read.md or its excerpts/*.md. That cap is a wiki-navigation rule
-      (index, learner/, etc.), not a teaching-content rule.
-    - Every high-relevance (>=0.6) source in the manifest MUST be cited
-      with at least one excerpt + explanation. Do not drop sources.
-    - Do not read wiki/learner/push-tactics.md directly — consume
-      push_tactic_snapshot as injected by the calling skill.
-    - Only write wiki/courses/<slug>/<chapter>/read.md and optional
-      wiki/courses/<slug>/<chapter>/excerpts/*.md. Nothing else.
-    - Edit tool not allowed; use Write with full content.
-    - Tactic-blind wiki-maintainer handles index + line-cap gating; do
-      not invoke other agents from here.
+      read.md or excerpts/*.md. That cap is a wiki-navigation rule only.
+    - Excerpts preserve original wording; paraphrase only in explanations.
+      Every code excerpt includes file:line citation as a comment.
+    - When >=2 high-relevance sources exist, the §N+1 synthesis section
+      (invariant vs variant) is required. Do not skip it.
+    - Mermaid diagrams (flowchart and/or sequence) are required in §1
+      when the mechanism is structural (control flow, state machine,
+      data flow). Skip only for purely declarative material (math proofs,
+      definitions).
+    - Do not read wiki/learner/push-tactics.md — consume snapshot from
+      the calling skill.
+    - Only write wiki/courses/<slug>/<chapter>/read.md and excerpts/*.md.
+      No other writes. Edit tool not allowed; use Write.
+    - Tactic-blind wiki-maintainer handles index + gating; do not invoke
+      other agents from here.
   </Constraints>
 
   <Final_Checklist>
     - Did I read crawl_manifest_path and filter to relevance >= 0.6?
-    - Does every high-relevance source have a walkthrough with a real
-      excerpt (>=5 lines), explanation, and connection?
-    - Are the three required sections present in order with valid
-      frontmatter (chapter, course, phase, tactic, sources_cited)?
-    - Did I split into sub-pages when content warranted (>1500 lines
-      or >=5 dense sources)?
-    - Applied push_tactic_snapshot to Overview tone and Questions style?
-    - Applied bar_adjustment to depth and question difficulty?
+    - Does Overview open with a Core Question blockquote?
+    - Does §1 include pattern pseudocode + "why inevitable" + (when
+      structural) a mermaid diagram?
+    - Does every high-relevance source have a §N walkthrough with real
+      excerpt (>=5 lines, fenced, file:line citation) + explanation +
+      Notice callout + connection to the universal pattern?
+    - Does §N+1 include a cross-implementation synthesis table and
+      invariant-vs-variant paragraph (required for >=2 sources)?
+    - Are Questions styled by tactic and does at least one cite a
+      specific excerpt?
+    - Did I split into sub-pages when content warranted (>2000 lines or
+      >=5 dense sources)?
+    - Applied push_tactic_snapshot tone + bar_adjustment depth?
     - Resisted the urge to produce a shallow bullet summary?
   </Final_Checklist>
 </Agent_Prompt>

--- a/tests/phase-4/agent-shapes.test.mjs
+++ b/tests/phase-4/agent-shapes.test.mjs
@@ -244,15 +244,25 @@ for (const [filename, stem] of AGENTS) {
     }
   });
 
-  // Check 6 — file is under 120 lines
-  test(`${stem}: should be under 120 lines`, async () => {
+  // Check 6 — file is within its per-agent line cap
+  //
+  // Default cap: 120 lines (keeps agent prompts LLM-context-friendly).
+  // Exception: creator.md has a 200-line cap because its contract is
+  // structurally richer than the other 8 agents — it must specify
+  // Core Question, universal pattern, per-impl walkthroughs,
+  // mermaid diagrams, file:line citations, Notice callouts, and
+  // invariant/variant synthesis, all in one prompt. The other agents
+  // produce narrower artifacts and fit comfortably under 120.
+  test(`${stem}: should be within its line cap`, async () => {
     // Arrange
     const { lines } = await loadAgent(filename);
+    const PER_AGENT_CAP = { 'creator': 200 };
+    const cap = PER_AGENT_CAP[stem] ?? 120;
 
     // Assert
     assert.ok(
-      lines <= 120,
-      `${filename}: file has ${lines} lines, exceeds 120-line cap`
+      lines <= cap,
+      `${filename}: file has ${lines} lines, exceeds ${cap}-line cap`
     );
   });
 

--- a/tests/phase-4/creator-depth-contract.test.mjs
+++ b/tests/phase-4/creator-depth-contract.test.mjs
@@ -60,6 +60,72 @@ test('creator.md supports multi-file output for dense chapters', async () => {
   );
 });
 
+// ---------------------------------------------------------------------------
+// The reference style is code-understanding-claude/docs — Core Question +
+// universal pattern + per-impl walkthroughs with file:line excerpts + Notice
+// callouts + cross-implementation synthesis. These assertions lock the
+// structural contract that enforces that tutorial-grade style.
+// ---------------------------------------------------------------------------
+
+test('creator.md requires a Core Question opener in Overview', async () => {
+  const src = await readFile(CREATOR_MD, 'utf8');
+  assert.match(
+    src,
+    /Core Question/,
+    'creator.md must require the Overview to open with a Core Question blockquote (matches code-understanding-claude style)'
+  );
+});
+
+test('creator.md requires a universal-pattern section before per-impl walkthroughs', async () => {
+  const src = await readFile(CREATOR_MD, 'utf8');
+  assert.match(
+    src,
+    /(Universal Pattern|universal pattern|pseudocode)/i,
+    'creator.md must require a §1 "Universal Pattern" section that distills the mechanism as pseudocode'
+  );
+  assert.match(
+    src,
+    /inevitable|consequence of the substrate/i,
+    'creator.md must require the "why this pattern is inevitable" framing (pattern follows from substrate, not design choice)'
+  );
+});
+
+test('creator.md requires mermaid diagrams for structural mechanisms', async () => {
+  const src = await readFile(CREATOR_MD, 'utf8');
+  assert.match(
+    src,
+    /mermaid/i,
+    'creator.md must require mermaid flowchart/sequence diagrams in §1 when the mechanism is structural'
+  );
+});
+
+test('creator.md requires file:line citations in code excerpts', async () => {
+  const src = await readFile(CREATOR_MD, 'utf8');
+  assert.match(
+    src,
+    /file:line|lines? [A-Z0-9]+-[A-Z0-9]+|line range/i,
+    'creator.md must require file:line citations on every code excerpt (matches reference style)'
+  );
+});
+
+test('creator.md requires "Notice..." callouts after each excerpt', async () => {
+  const src = await readFile(CREATOR_MD, 'utf8');
+  assert.match(
+    src,
+    /"?Notice\b/,
+    'creator.md must require a "Notice ..." callout after each excerpt to surface non-obvious design choices'
+  );
+});
+
+test('creator.md requires a cross-implementation synthesis section', async () => {
+  const src = await readFile(CREATOR_MD, 'utf8');
+  assert.match(
+    src,
+    /(synthesis|invariant.*variant|cross-impl)/i,
+    'creator.md must require a synthesis section comparing invariant (substrate-forced) vs variant (design-choice) across implementations'
+  );
+});
+
 test('skills/learn/SKILL.md passes crawl_manifest_path to creator', async () => {
   const src = await readFile(LEARN_MD, 'utf8');
   assert.match(


### PR DESCRIPTION
## Summary

Follow-up to #12 after the user pointed at the reference style:
\`/Users/jaewon/mywork_2026/_for_fun/code-understanding-claude/docs\`.
That tutorial series defines the quality bar — chapters average ~800 lines and follow a distinctive structure:

- \`> **Core Question:** …\` opener
- Section 1: Universal pattern distilled as pseudocode + **why this pattern is inevitable** (consequence of substrate, not design choice) + mental-model analogy + mermaid flowchart/sequence diagram
- Sections 2-N: Per-implementation walkthroughs, each with file:line-cited code excerpts + "Notice …" callouts surfacing non-obvious choices + connection back to the universal pattern
- Section N+1: Cross-implementation synthesis (comparison table + invariant-vs-variant paragraph)

My previous #12 patch fixed the depth bug (crawl-manifest wiring, 120-line cap exemption) but didn't capture this richer structural contract. Result: creator would produce depth but not necessarily the *shape* the user wants.

## Changes

### \`agents/creator.md\` — structural contract
- \`## Overview\` must open with a Core Question blockquote
- \`## Key Concepts\` must be organized as numbered \`###\` subsections:
  - \`### 1. The Universal Pattern\` — pseudocode + inevitability framing + optional mental-model + mermaid when structural
  - \`### 2-N. Per-Implementation Walkthroughs\` — one per high-relevance source, with file:line excerpt + explanation + Notice callout + connection
  - \`### N+1. Synthesis\` — comparison table + invariant vs variant paragraph (required for >=2 sources)
- Mermaid diagrams required for structural mechanisms
- File:line citations required on every code excerpt

### \`tests/phase-4/creator-depth-contract.test.mjs\` — 6 new regression assertions
Locks: Core Question opener, Universal Pattern + "inevitable"/"substrate" framing, mermaid requirement, file:line citations, Notice callouts, cross-implementation synthesis.

### \`tests/phase-4/agent-shapes.test.mjs\` — per-agent line caps
\`creator.md\`'s cap raised to 200 lines (from 120). The other 8 agents stay at 120. Rationale: creator produces the most complex artifact, so its contract is inherently richer. The old uniform 120-line cap was forcing omission.

## Test plan

- [x] Full suite: **323/323 passing** (was 317, +6 new contract assertions)
- [x] \`creator.md\` is 160 lines (within the new 200-line cap); other agents unchanged
- [x] No regressions in the other 8 agents, 8 skills, 5 hooks, MCP server, or dashboard

## Expected output (re-running on boson-agent ch-01)

The \`read.md\` should now open with a Core Question, establish the universal pattern with pseudocode + diagram, walk through each of the 5+ high-relevance sources with file:line excerpts + Notice callouts, and close with a synthesis section — matching the reference chapters in length (~400-1200 lines) and structure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)